### PR TITLE
change repository schema to https in package.json;

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/betaagency-os/declint-ru.git"
+    "url": "https://github.com/betaagency-os/declint-ru.git"
   },
   "keywords": [
     "declension",


### PR DESCRIPTION
Hi!

Our private npm registry supported by Artifactory cannot cache this module from public npm registry correctly. 
The URL git://.... looked suspicious for me. So it works with https:// scheme.
 
I haven't investigated this behavior yet. 